### PR TITLE
Add Github Workflow for building Python wheels and publish them to PyPI

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -30,7 +30,6 @@ jobs:
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          echo "$RUNNER_OS"
           PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
           echo $PLAT
           python setup.py sdist -d wheelhouse

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -7,11 +7,8 @@ on:
   #   types: [created]
 
 jobs:
-  deploy:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  deploy-linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
@@ -21,19 +18,47 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
+          python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
       - name: Build and publish
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-*"
-          RUNNER_OS: ${{ runner.os }}
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
-          echo $PLAT
+          # PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
+          # echo $PLAT
           python setup.py sdist -d wheelhouse
-          cibuildwheel --platform $PLAT --output-dir wheelhouse
+          python -m cibuildwheel --platform linux --output-dir wheelhouse
+      - name: List wheels 
+        run: |
+          ls -ltrh wheelhouse
+          # python setup.py sdist bdist_wheel
+          # twine upload dist/*
+
+
+  deploy-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
+      - name: Build and publish
+        env:
+          CIBW_BEFORE_BUILD: "sudo port install gcc6 +gfortran && pip install -U numpy"
+          CIBW_SKIP: "cp27-* cp34-*"
+         
+        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist -d wheelhouse
+          python -m cibuildwheel --platform macos --output-dir wheelhouse
       - name: List wheels 
         run: |
           ls -ltrh wheelhouse

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -23,20 +23,13 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-* cp35-*"
-        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           # PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
           # echo $PLAT
-          python setup.py sdist -d wheelhouse
-          python -m cibuildwheel --platform linux --output-dir wheelhouse
-      - name: List wheels 
-        run: |
-          ls -ltrh wheelhouse
-          # python setup.py sdist bdist_wheel
-          # twine upload dist/*
-
-
+          python setup.py sdist -d $GITHUB_WORKSPACE/wheelhouseLinux
+          python -m cibuildwheel --platform linux --output-dir $GITHUB_WORKSPACE/wheelhouseLinux
+    
+  
   deploy-macos:
     runs-on: macos-latest
     steps:
@@ -54,19 +47,10 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-* cp35-*"
-         
-        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python setup.py sdist -d wheelhouse
-          python -m cibuildwheel --platform macos --output-dir wheelhouse
-      - name: List wheels 
-        run: |
-          ls -ltrh wheelhouse
-          # python setup.py sdist bdist_wheel
-          # twine upload dist/*
+          python -m cibuildwheel --platform macos --output-dir $GITHUB_WORKSPACE/wheelhouseMacOS
 
-  
+
   # deploy-windows:
   #   runs-on: macos-latest
   #   steps:
@@ -94,3 +78,25 @@ jobs:
   #         ls -ltrh wheelhouse
   #         # python setup.py sdist bdist_wheel
   #         # twine upload dist/*
+ 
+  deploy:
+    needs: [deploy-linux, deploy-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip twine 
+      
+      - name: Publish 
+        # env:
+        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          cd $GITHUB_WORKSPACE
+          ls -ltrh wheelhouseMacOS/ wheelhouseLinux/
+          # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -13,26 +13,28 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
-    - name: Build and publish
-      env:
-        CIBW_BEFORE_BUILD: "pip install -U numpy"
-        CIBW_SKIP: "cp27-* cp34-*"
-      #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist -d wheelhouse
-        cibuildwheel --platform linux --output-dir wheelhouse
-    - name: List wheels 
-      run: |
-        ls -ltrh wheelhouse
-        # python setup.py sdist bdist_wheel
-        # twine upload dist/*
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
+      - name: Build and publish
+        env:
+          CIBW_BEFORE_BUILD: "pip install -U numpy"
+          CIBW_SKIP: "cp27-* cp34-*"
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          echo "$RUNNER_CONTEXT"
+          python setup.py sdist -d wheelhouse
+          cibuildwheel --platform linux --output-dir wheelhouse
+      - name: List wheels 
+        run: |
+          ls -ltrh wheelhouse
+          # python setup.py sdist bdist_wheel
+          # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -27,6 +27,6 @@ jobs:
       #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist -d wheelhouse
-        cibuildwheel --output-dir wheelhouse
+        cibuildwheel --platform linux --output-dir wheelhouse
         # python setup.py sdist bdist_wheel
         # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
-      - name: Build and publish
+      - name: Build
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-* cp35-*"
@@ -28,6 +28,12 @@ jobs:
           # echo $PLAT
           python setup.py sdist -d $GITHUB_WORKSPACE/wheelhouseLinux
           python -m cibuildwheel --platform linux --output-dir $GITHUB_WORKSPACE/wheelhouseLinux
+
+      - name: Archive wheels 
+        uses: actions/upload-artifact@v1
+        with:
+          name: wheelhouseLinux
+          path: $GITHUB_WORKSPACE/wheelhouseLinux
     
   
   deploy-macos:
@@ -43,42 +49,18 @@ jobs:
           brew install gcc
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
-      - name: Build and publish
+      - name: Build
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-* cp35-*"
         run: |
           python -m cibuildwheel --platform macos --output-dir $GITHUB_WORKSPACE/wheelhouseMacOS
 
-
-  # deploy-windows:
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: '3.x'
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
-  #     - name: Build and publish
-  #       env:
-  #         CIBW_BEFORE_BUILD: "pip install -U numpy"
-  #         CIBW_SKIP: "cp27-* cp34-* cp35-*"
-          
-  #       #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-  #       #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-  #       run: |
-  #         python setup.py sdist -d wheelhouse
-  #         python -m cibuildwheel --platform windows --output-dir wheelhouse
-  #     - name: List wheels 
-  #       run: |
-  #         ls -ltrh wheelhouse
-  #         # python setup.py sdist bdist_wheel
-  #         # twine upload dist/*
- 
+      - name: Archive wheels 
+        uses: actions/upload-artifact@v1
+        with:
+          name: wheelhouseMacOS
+          path: $GITHUB_WORKSPACE/wheelhouseMacOS
   deploy:
     needs: [deploy-linux, deploy-macos]
     runs-on: ubuntu-latest
@@ -90,7 +72,17 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip twine 
+          python -m pip install --upgrade pip twine
+
+      - name: Download archived MacOS wheels
+        uses: actions/download-artifact@v1
+        with:
+          name: wheelhouseMacOS
+
+      - name: Download archived Linux wheels
+        uses: actions/download-artifact@v1
+        with:
+          name: wheelhouseLinux
       
       - name: Publish 
         # env:

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -67,30 +67,30 @@ jobs:
           # twine upload dist/*
 
   
-  deploy-windows:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
-      - name: Build and publish
-        env:
-          CIBW_BEFORE_BUILD: "pip install -U numpy"
-          CIBW_SKIP: "cp27-* cp34-* cp35-*"
+  # deploy-windows:
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: '3.x'
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
+  #     - name: Build and publish
+  #       env:
+  #         CIBW_BEFORE_BUILD: "pip install -U numpy"
+  #         CIBW_SKIP: "cp27-* cp34-* cp35-*"
           
-        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist -d wheelhouse
-          python -m cibuildwheel --platform windows --output-dir wheelhouse
-      - name: List wheels 
-        run: |
-          ls -ltrh wheelhouse
-          # python setup.py sdist bdist_wheel
-          # twine upload dist/*
+  #       #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+  #       #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  #       run: |
+  #         python setup.py sdist -d wheelhouse
+  #         python -m cibuildwheel --platform windows --output-dir wheelhouse
+  #     - name: List wheels 
+  #       run: |
+  #         ls -ltrh wheelhouse
+  #         # python setup.py sdist bdist_wheel
+  #         # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -47,11 +47,12 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
+          brew install gcc
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
       - name: Build and publish
         env:
-          CIBW_BEFORE_BUILD: "sudo port install gcc6 +gfortran && pip install -U numpy"
+          CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-*"
          
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -31,7 +31,7 @@ jobs:
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           echo "$RUNNER_OS"
-          PLAT = `echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
+          PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
           echo $PLAT
           python setup.py sdist -d wheelhouse
           cibuildwheel --platform $PLAT --output-dir wheelhouse

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools setuptools-scm cibuildwheel wheel twine
+        pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
     - name: Build and publish
       env:
         CIBW_BEFORE_BUILD: "pip install -U numpy"

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -1,0 +1,28 @@
+name: Upload Python Package
+
+on:
+  push:
+    branches: "*"
+  # release:
+  #   types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools setuptools-scm wheel twine
+    - name: Build and publish
+      # env:
+      #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -10,7 +10,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -22,8 +22,6 @@ jobs:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-* cp35-*"
         run: |
-          # PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
-          # echo $PLAT
           python setup.py sdist -d wheelhouseLinux
           python -m cibuildwheel --platform linux --output-dir wheelhouseLinux
 

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -31,9 +31,10 @@ jobs:
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           echo "$RUNNER_OS"
-          echo "$RUNNER_OS" | awk '{ print tolower($1) }'
+          PLAT = `echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
+          echo $PLAT
           python setup.py sdist -d wheelhouse
-          cibuildwheel --platform echo "$RUNNER_OS" | awk '{ print tolower($1) }' --output-dir wheelhouse
+          cibuildwheel --platform $PLAT --output-dir wheelhouse
       - name: List wheels 
         run: |
           ls -ltrh wheelhouse

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -28,5 +28,8 @@ jobs:
       run: |
         python setup.py sdist -d wheelhouse
         cibuildwheel --platform linux --output-dir wheelhouse
+    - name: List wheels 
+      run: |
+        ls -ltrh wheelhouse
         # python setup.py sdist bdist_wheel
         # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -26,14 +26,14 @@ jobs:
         run: |
           # PLAT=`echo "$RUNNER_OS" | awk '{ print tolower($1) }'`
           # echo $PLAT
-          python setup.py sdist -d $GITHUB_WORKSPACE/wheelhouseLinux
-          python -m cibuildwheel --platform linux --output-dir $GITHUB_WORKSPACE/wheelhouseLinux
+          python setup.py sdist -d wheelhouseLinux
+          python -m cibuildwheel --platform linux --output-dir wheelhouseLinux
 
       - name: Archive wheels 
         uses: actions/upload-artifact@v1
         with:
           name: wheelhouseLinux
-          path: $GITHUB_WORKSPACE/wheelhouseLinux
+          path: wheelhouseLinux
     
   
   deploy-macos:
@@ -54,13 +54,13 @@ jobs:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-* cp35-*"
         run: |
-          python -m cibuildwheel --platform macos --output-dir $GITHUB_WORKSPACE/wheelhouseMacOS
+          python -m cibuildwheel --platform macos --output-dir wheelhouseMacOS
 
       - name: Archive wheels 
         uses: actions/upload-artifact@v1
         with:
           name: wheelhouseMacOS
-          path: $GITHUB_WORKSPACE/wheelhouseMacOS
+          path: wheelhouseMacOS
   deploy:
     needs: [deploy-linux, deploy-macos]
     runs-on: ubuntu-latest
@@ -89,6 +89,5 @@ jobs:
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          cd $GITHUB_WORKSPACE
           ls -ltrh wheelhouseMacOS/ wheelhouseLinux/
           # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -26,13 +26,14 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
           CIBW_SKIP: "cp27-* cp34-*"
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
+          RUNNER_OS: ${{ runner.os }}
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          echo "$RUNNER_CONTEXT"
+          echo "$RUNNER_OS"
+          echo "$RUNNER_OS" | awk '{ print tolower($1) }'
           python setup.py sdist -d wheelhouse
-          cibuildwheel --platform linux --output-dir wheelhouse
+          cibuildwheel --platform echo "$RUNNER_OS" | awk '{ print tolower($1) }' --output-dir wheelhouse
       - name: List wheels 
         run: |
           ls -ltrh wheelhouse

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Build and publish
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
-          CIBW_SKIP: "cp27-* cp34-*"
+          CIBW_SKIP: "cp27-* cp34-* cp35-*"
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
@@ -53,13 +53,42 @@ jobs:
       - name: Build and publish
         env:
           CIBW_BEFORE_BUILD: "pip install -U numpy"
-          CIBW_SKIP: "cp27-* cp34-*"
+          CIBW_SKIP: "cp27-* cp34-* cp35-*"
          
         #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist -d wheelhouse
           python -m cibuildwheel --platform macos --output-dir wheelhouse
+      - name: List wheels 
+        run: |
+          ls -ltrh wheelhouse
+          # python setup.py sdist bdist_wheel
+          # twine upload dist/*
+
+  
+  deploy-windows:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools setuptools-scm numpy cibuildwheel wheel twine
+      - name: Build and publish
+        env:
+          CIBW_BEFORE_BUILD: "pip install -U numpy"
+          CIBW_SKIP: "cp27-* cp34-* cp35-*"
+          
+        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist -d wheelhouse
+          python -m cibuildwheel --platform windows --output-dir wheelhouse
       - name: List wheels 
         run: |
           ls -ltrh wheelhouse

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -18,11 +18,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools setuptools-scm wheel twine
+        pip install setuptools setuptools-scm cibuildwheel wheel twine
     - name: Build and publish
-      # env:
+      env:
+        CIBW_BEFORE_BUILD: "pip install -U numpy"
+        CIBW_SKIP: "cp27-* cp34-*"
       #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
       #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python setup.py sdist -d wheelhouse
+        cibuildwheel --output-dir wheelhouse
+        # python setup.py sdist bdist_wheel
         # twine upload dist/*

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -1,10 +1,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    branches: "*"
-  # release:
-  #   types: [created]
+  release:
+    types: [created]
 
 jobs:
   deploy-linux:
@@ -85,9 +83,9 @@ jobs:
           name: wheelhouseLinux
       
       - name: Publish 
-        # env:
-        #   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        #   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           ls -ltrh wheelhouseMacOS/ wheelhouseLinux/
-          # twine upload dist/*
+          twine upload --skip-existing wheelhouseLinux/* wheelhouseMacOS/*


### PR DESCRIPTION
Towards fixing #5 

For this workflow to automatically upload these wheels to PyPI (after a release is created), the repo admin will need to add `PYPI_USERNAME` and `PYPI_PASSWORD` secrets in https://github.com/cspencerjones/xlayers/settings/secrets

This workflow is triggered whenever a release is created on Github. 

Here are the [logs of how this workflow works](https://github.com/andersy005/xlayers/commit/08f503218610cf1f95894abbbf67173297c3fafb/checks?check_suite_id=369066004)